### PR TITLE
import ordered collections

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
 		.target(
 			name: "AsyncFileMonitor",
 			dependencies: [
-				.product(name: "Collections", package: "swift-collections")
+				.product(name: "OrderedCollections", package: "swift-collections")
 			],
 			exclude: []
 		),

--- a/Tests/RaceConditionTests/2_ActorExecutorCoordination/TestStreamRegistrar.swift
+++ b/Tests/RaceConditionTests/2_ActorExecutorCoordination/TestStreamRegistrar.swift
@@ -8,7 +8,7 @@
 //  This was part of the main implementation before migration to direct AsyncStream approach.
 //
 
-import Collections
+import OrderedCollections
 import Foundation
 
 @testable import AsyncFileMonitor


### PR DESCRIPTION
The package manifest from `swift-collections` publishes "subpackages". As an alternative to importing the complete package we can choose to only import the slice we need. This can help reduce the binary size impact of our own package.